### PR TITLE
Nyangumarta translation

### DIFF
--- a/babelon/hp-nna.babelon.tsv
+++ b/babelon/hp-nna.babelon.tsv
@@ -1,0 +1,202 @@
+source_language	translation_language	subject_id	predicate_id	source_value	translation_value	translation_status
+en	nna	HP:0000252	rdfs:label	Microcephaly	Jurnturtu Wupartu	OFFICIAL
+en	nna	HP:0000256	rdfs:label	Macrocephaly	Jurnturtu Wirtu	OFFICIAL
+en	nna	HP:0000262	rdfs:label	Turricephaly	Jurnturtu  Makanu	OFFICIAL
+en	nna	HP:0000248	rdfs:label	Brachycephaly	Jurnturtu Makanu Jarnti	OFFICIAL
+en	nna	HP:0000268	rdfs:label	Dolichocephaly	Jurnturtu makanu karta	OFFICIAL
+en	nna	HP:0002676	rdfs:label	Cloverleaf skull	Ngartin Wirtu	OFFICIAL
+en	nna	HP:0005469	rdfs:label	Flat occiput	Taki Lalypa	OFFICIAL
+en	nna	HP:0000269	rdfs:label	Prominent occiput	Taki Wirtu	OFFICIAL
+en	nna	HP:0001357	rdfs:label	Plagiocephaly	Jurnturtu Palyparr-Palyparr	OFFICIAL
+en	nna	HP:0000243	rdfs:label	Trigonocephaly	Yirikarta Jurnturtu	OFFICIAL
+en	nna	HP:0009890	rdfs:label	High anterior hairline	Pirrin Pinyajarr	OFFICIAL
+en	nna	HP:0000294	rdfs:label	Low anterior hairline	Purrunyju Pirrinyarma	OFFICIAL
+en	nna	HP:0002292	rdfs:label	Frontal balding	Jurnurtu Pararra	OFFICIAL
+en	nna	HP:0002209	rdfs:label	Sparse scalp hair	Purruny Mampumajirri	OFFICIAL
+en	nna	HP:0000349	rdfs:label	Widow's peak	Purruny Yirikata	OFFICIAL
+en	nna	HP:0000276	rdfs:label	Long face	Ngumpa  Makanu	OFFICIAL
+en	nna	HP:0000311	rdfs:label	Round face	Ngumpa  Mamurarri	OFFICIAL
+en	nna	HP:0000283	rdfs:label	Broad face	Ngumpa Walpurra	OFFICIAL
+en	nna	HP:0000280	rdfs:label	Coarse facial features	Ngumpa Kulujartin	OFFICIAL
+en	nna	HP:0012368	rdfs:label	Flat face	Ngumpa Lalypa	OFFICIAL
+en	nna	HP:0000275	rdfs:label	Narrow face	Ngumpa Murrjartin	OFFICIAL
+en	nna	HP:0011219	rdfs:label	Short face	Ngumpa Murlku	OFFICIAL
+en	nna	HP:0000321	rdfs:label	Square face	Ngumpa Square	OFFICIAL
+en	nna	HP:0000325	rdfs:label	Triangular face	Ngumpa Yirikata	OFFICIAL
+en	nna	HP:0000278	rdfs:label	Retrognathia	Ngarn-Ngarn Wupartu	OFFICIAL
+en	nna	HP:0000303	rdfs:label	Mandibular prognathia	Ngarn-Ngarn Wirtu	OFFICIAL
+en	nna	HP:0012802	rdfs:label	Broad jaw	Ngarn-Ngarn Walpurra	OFFICIAL
+en	nna	HP:0012801	rdfs:label	Narrow jaw	Ngarn-Ngarn Murrjartin	OFFICIAL
+en	nna	HP:0010752	rdfs:label	Cleft mandible	Murtirr Larr	OFFICIAL
+en	nna	HP:0000347	rdfs:label	Micrognathia	Ngarn-Ngarn Wupartu	OFFICIAL
+en	nna	HP:0010751	rdfs:label	Dimple chin	Ngarn-Ngarn Martu	OFFICIAL
+en	nna	HP:0400000	rdfs:label	Tall chin	Ngarn-Ngarn Makanu	OFFICIAL
+en	nna	HP:0000307	rdfs:label	Pointed chin	Ngarn-Ngarn Yirikata	OFFICIAL
+en	nna	HP:0000307	rdfs:label	Pointed chin	Ngarn-Ngarn Murlku	OFFICIAL
+en	nna	HP:0000475	rdfs:label	Broad neck	Ngalyi Walpurra	OFFICIAL
+en	nna	HP:0000465	rdfs:label	Webbed neck	Ngalyi Karnu Walpurra	OFFICIAL
+en	nna	HP:0000472	rdfs:label	Long neck	Ngalyi  Makanu	OFFICIAL
+en	nna	HP:0000470	rdfs:label	Short neck	Ngalyi  Murlku	OFFICIAL
+en	nna	HP:0005989	rdfs:label	Redundant neck skin	Ngalyi Kurtan Kurtan	OFFICIAL
+en	nna	HP:0000293	rdfs:label	Full cheeks	Nginngirr Jinjimama	OFFICIAL
+en	nna	HP:0009938	rdfs:label	Sunken cheeks	Nginngirr Martu	OFFICIAL
+en	nna	HP:0012370	rdfs:label	Prominence of the zygomatic bone	Nginngirr Kunja jakun	OFFICIAL
+en	nna	HP:0010669	rdfs:label	Hypoplasia of the zygomatic bone	Nginngirr Wupartu	OFFICIAL
+en	nna	HP:0010620	rdfs:label	Malar prominence	Nginngirr Wirtu	OFFICIAL
+en	nna	HP:0010759	rdfs:label	Prominence of the premaxilla	Japirr Wirtu	OFFICIAL
+en	nna	HP:0010650	rdfs:label	Hypoplasia of the premaxilla	Japirr Wupartu	OFFICIAL
+en	nna	HP:0011220	rdfs:label	Prominent forehead	Pirrirn Wirtu	OFFICIAL
+en	nna	HP:0000337	rdfs:label	Broad forehead	Pirrirn Walpurra	OFFICIAL
+en	nna	HP:0000341	rdfs:label	Narrow forehead	Pirrin Murrjartin	OFFICIAL
+en	nna	HP:0000336	rdfs:label	Prominent supraorbital ridges	Wirtu Jalparn Kunja	OFFICIAL
+en	nna	HP:0009891	rdfs:label	Underdeveloped supraorbital ridges	Laypa Jalparn Kunja	OFFICIAL
+en	nna	HP:0011224	rdfs:label	Ablepharon	Jirtamarra Kurnumajarri	OFFICIAL
+en	nna	HP:0009755	rdfs:label	Ankyloblepharon	Jirtamarra Karnu Kurlanupulaninyi	OFFICIAL
+en	nna	HP:0000653	rdfs:label	Sparse eyelashes	Eyelash Majirri	OFFICIAL
+en	nna	HP:0010749	rdfs:label	Blepharochalasis	Kurtan-Kurtan Jirtamarra  Karnu	OFFICIAL
+en	nna	HP:0000508	rdfs:label	Ptosis	Pani Kartakarra	OFFICIAL
+en	nna	HP:0000527	rdfs:label	Long eyelashes	Eyelash Makanu	OFFICIAL
+en	nna	HP:0001126	rdfs:label	Cryptophthalmos	Panimajirri	OFFICIAL
+en	nna	HP:0000656	rdfs:label	Ectropion	Pani karnu kurtan-kurtan	OFFICIAL
+en	nna	HP:0000490	rdfs:label	Deeply set eye	Pani Martu	OFFICIAL
+en	nna	HP:0012745	rdfs:label	Short palpebral fissure	Pani Murrjartin	OFFICIAL
+en	nna	HP:0000574	rdfs:label	Thick eyebrow	Jalparn Purrun Wirtu	OFFICIAL
+en	nna	HP:0000581	rdfs:label	Blepharophimosis	Pani Wupartu	OFFICIAL
+en	nna	HP:0001129	rdfs:label	Large central visual field defect	Jalparn Walpurra	OFFICIAL
+en	nna	HP:0002553	rdfs:label	Highly arched eyebrow	Jalparn Kangkajirri	OFFICIAL
+en	nna	HP:0011228	rdfs:label	Horizontal eyebrow	Jalparn Kirrpirnti	OFFICIAL
+en	nna	HP:0011230	rdfs:label	Laterally extended eyebrow	Jalparn Makanu	OFFICIAL
+en	nna	HP:0045075	rdfs:label	Sparse eyebrow	Jalparn Wupartu	OFFICIAL
+en	nna	HP:0200102	rdfs:label	Sparse or absent eyelashes	Eyelash Majirri	OFFICIAL
+en	nna	HP:0011231	rdfs:label	Prominent eyelashes	Eyelash Makanu	OFFICIAL
+en	nna	HP:0000625	rdfs:label	Eyelid coloboma	Pani Kurtan-Kurtan?	OFFICIAL
+en	nna	HP:0000601	rdfs:label	Hypotelorism	Pani Wangkakulu	OFFICIAL
+en	nna	HP:0000316	rdfs:label	Hypertelorism	Pani Kajakul	OFFICIAL
+en	nna	HP:0100876	rdfs:label	Infra-orbital crease	Pani Kaniny kutany kutany	OFFICIAL
+en	nna	HP:0001092	rdfs:label	Absent lacrimal punctum	Yilyu Majirri	OFFICIAL
+en	nna	HP:0030003	rdfs:label	Paralytic lagophthalmos	Jirtamarra Mintu	OFFICIAL
+en	nna	HP:0000582	rdfs:label	Upslanted palpebral fissure	Pani Kaninykurnu	OFFICIAL
+en	nna	HP:0000637	rdfs:label	Long palpebral fissure	Jirtamarra Makanu	OFFICIAL
+en	nna	HP:0000664	rdfs:label	Synophrys	Warajanga Jalparn	OFFICIAL
+en	nna	HP:0012724	rdfs:label	Upper eyelid edema	Pijurnu Kakarni Pani	OFFICIAL
+en	nna	HP:0000520	rdfs:label	Proptosis	Pani Wirtu	OFFICIAL
+en	nna	HP:0009892	rdfs:label	Anotia	Kurlka Majarri	OFFICIAL
+en	nna	HP:0000411	rdfs:label	Protruding ear	Kurlka Wirtu	OFFICIAL
+en	nna	HP:0011266	rdfs:label	Microtia, first degree	Kurlka Wupartu	OFFICIAL
+en	nna	HP:0008569	rdfs:label	Microtia, second degree	Kurlka Wupartu	OFFICIAL
+en	nna	HP:0011267	rdfs:label	Microtia, third degree	Kurlka Wupartu	OFFICIAL
+en	nna	HP:0009901	rdfs:label	Crumpled ear	Kurlka Wujul	OFFICIAL
+en	nna	HP:0030676	rdfs:label	Satyr ear	Kurlka Yiri	OFFICIAL
+en	nna	HP:0400003	rdfs:label	Focal absence of the external ear	Kurlka Pirli jartiny	OFFICIAL
+en	nna	HP:0400004	rdfs:label	Long ear	Makanu Kurlka	OFFICIAL
+en	nna	HP:0000369	rdfs:label	Low-set ears	Kurlka Kaninykurnu	OFFICIAL
+en	nna	HP:0400005	rdfs:label	Short ear	Kurlka Murlku	OFFICIAL
+en	nna	HP:0003191	rdfs:label	Cleft ala nasi	Milya Larr Jartiny	OFFICIAL
+en	nna	HP:0000463	rdfs:label	Anteverted nares	Milya Yiri	OFFICIAL
+en	nna	HP:0009934	rdfs:label	Supernumerary naris	Kujarra Milya	OFFICIAL
+en	nna	HP:0012809	rdfs:label	Narrow nasal base	Nyurrurn-Nyurrurn Murrjartin	OFFICIAL
+en	nna	HP:0012810	rdfs:label	Wide nasal base	Nyurrurn-Nyurrurn Walpurra	OFFICIAL
+en	nna	HP:0005280	rdfs:label	Depressed nasal bridge	Nyurrurn-Nyurrurn Martu	OFFICIAL
+en	nna	HP:0000426	rdfs:label	Prominent nasal bridge	Wirtu Nyurrurn-Nyurrurn	OFFICIAL
+en	nna	HP:0000446	rdfs:label	Narrow nasal bridge	Wujul-Wujul Nyurrurn-Nyurrurn	OFFICIAL
+en	nna	HP:0000431	rdfs:label	Wide nasal bridge	Walpurra Nyurrurn-Nyurrurn	OFFICIAL
+en	nna	HP:0030028	rdfs:label	Absent nasal cartilage	Japirr Majirri	OFFICIAL
+en	nna	HP:0011120	rdfs:label	Concave nasal ridge	Nyurrun-Nyurrun Kaninykurnu	OFFICIAL
+en	nna	HP:0000444	rdfs:label	Convex nasal ridge	Nyurrun-Nyurrun Kankakurnu	OFFICIAL
+en	nna	HP:0000457	rdfs:label	Depressed nasal ridge	Kaninykurnu Nyurrun-Nyurrun	OFFICIAL
+en	nna	HP:0000418	rdfs:label	Narrow nasal ridge	Nyurrun-Nyurrun Wujul	OFFICIAL
+en	nna	HP:0012811	rdfs:label	Wide nasal ridge	Nyurrun-Nyurrun Wirtu	OFFICIAL
+en	nna	HP:0009927	rdfs:label	Aplasia of the nose	Milya Majirri	OFFICIAL
+en	nna	HP:0011803	rdfs:label	Bifid nose	Milya Larr	OFFICIAL
+en	nna	HP:0003189	rdfs:label	Long nose	Makanu Milya	OFFICIAL
+en	nna	HP:0000460	rdfs:label	Narrow nose	Wujul-Wujul Milya	OFFICIAL
+en	nna	HP:0000448	rdfs:label	Prominent nose	Milya Wirtu	OFFICIAL
+en	nna	HP:0003196	rdfs:label	Short nose	Milya Murlku	OFFICIAL
+en	nna	HP:0000445	rdfs:label	Wide nose	Walpurra Milya	OFFICIAL
+en	nna	HP:0000289	rdfs:label	Broad philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny Walpurra	OFFICIAL
+en	nna	HP:0002002	rdfs:label	Deep philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny Martu	OFFICIAL
+en	nna	HP:0000319	rdfs:label	Smooth philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny kapuraly	OFFICIAL
+en	nna	HP:0000343	rdfs:label	Long philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny Makanu	OFFICIAL
+en	nna	HP:0011826	rdfs:label	Philtrum with midline raphe	Milyanga-pa Japirr-ja Partijirri-kaniny Kujarra karnta	OFFICIAL
+en	nna	HP:0011829	rdfs:label	Narrow philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny. Wujul-wujul	OFFICIAL
+en	nna	HP:0000322	rdfs:label	Short philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny. Mulku	OFFICIAL
+en	nna	HP:0011825	rdfs:label	Tented philtrum	Milyanga-pa Japirr-ja Partijirri-kaniny.	OFFICIAL
+en	nna	HP:0002710	rdfs:label	Commissural lip pit	Ngingirr-ja Kaniny-karti wupartu martu	OFFICIAL
+en	nna	HP:0010800	rdfs:label	Absent cupid's bow	Japirr Jirumpu	OFFICIAL
+en	nna	HP:0100267	rdfs:label	Lip pit	Mutirr-ja Matru	OFFICIAL
+en	nna	HP:0000219	rdfs:label	Thin upper lip vermilion	Japirr Kankarni Wupartu	OFFICIAL
+en	nna	HP:0000232	rdfs:label	Everted lower lip vermilion	Mutirr-Kaniny kurtan-kurtan	OFFICIAL
+en	nna	HP:0000179	rdfs:label	Thick lower lip vermilion	Mutirr Kankarni Wirtu	OFFICIAL
+en	nna	HP:0010804	rdfs:label	Tented upper lip vermilion	Kankajirri Japirr Yirikarta	OFFICIAL
+en	nna	HP:0010802	rdfs:label	Perioral hyperpigmentation	Jawa Nyimil-nymil	OFFICIAL
+en	nna	HP:0010282	rdfs:label	Thin lower lip vermilion	Mutirr Kankarni Wupartu	OFFICIAL
+en	nna	HP:0010803	rdfs:label	Everted upper lip vermilion	Japirr Kankarni Kurtan-Kurtan	OFFICIAL
+en	nna	HP:0000215	rdfs:label	Thick upper lip vermilion	Japirr Kankarni Wirtu	OFFICIAL
+en	nna	HP:0000154	rdfs:label	Wide mouth	Jawa Wartu	OFFICIAL
+en	nna	HP:0000160	rdfs:label	Narrow mouth	Jawa  Makanu	OFFICIAL
+en	nna	HP:0000171	rdfs:label	Microglossia	Jalin Wupartu	OFFICIAL
+en	nna	HP:0000158	rdfs:label	Macroglossia	Jalin Wirtu	OFFICIAL
+en	nna	HP:0000180	rdfs:label	Lobulated tongue	Jalin Larrjartiny	OFFICIAL
+en	nna	HP:0010808	rdfs:label	Protruding tongue	Jalin Kurtany	OFFICIAL
+en	nna	HP:0010298	rdfs:label	Smooth tongue	Jalin Kapuraly	OFFICIAL
+en	nna	HP:0000221	rdfs:label	Furrowed tongue	Jalin Jikirr- Jikirr	OFFICIAL
+en	nna	HP:0010727	rdfs:label	Spontaneous rupture of the globe	Jalin Larr	OFFICIAL
+en	nna	HP:0006315	rdfs:label	Solitary median maxillary central incisor	Karniny Waraja Rirra Wirtu	OFFICIAL
+en	nna	HP:0000678	rdfs:label	Dental crowding	Kurrngal Rirra Ngapapa Purlu	OFFICIAL
+en	nna	HP:0000687	rdfs:label	Widely spaced teeth	Rirra Kajakul-Kajakul	OFFICIAL
+en	nna	HP:0001572	rdfs:label	Macrodontia	Rirra Wirtu	OFFICIAL
+en	nna	HP:0000691	rdfs:label	Microdontia	Rirra  Wupartu	OFFICIAL
+en	nna	HP:0010807	rdfs:label	Open bite	Rirra Open	OFFICIAL
+en	nna	HP:0010744	rdfs:label	Absent metatarsal bone	Jina Majirri	OFFICIAL
+en	nna	HP:0006265	rdfs:label	Aplasia/Hypoplasia of fingers	Parirr Wupartu	OFFICIAL
+en	nna	HP:0005927	rdfs:label	Aplasia/hypoplasia involving bones of the hand	Parirr  Wupartu	OFFICIAL
+en	nna	HP:0001832	rdfs:label	Abnormal metatarsal morphology	Makanu Jina	OFFICIAL
+en	nna	HP:0001786	rdfs:label	Narrow foot	Wujul-wujul Jina	OFFICIAL
+en	nna	HP:0001763	rdfs:label	Pes planus	Jina lalypa	OFFICIAL
+en	nna	HP:0001857	rdfs:label	Short distal phalanx of toe	Murlku Toes	OFFICIAL
+en	nna	HP:0009882	rdfs:label	Short distal phalanx of finger	Murlku Fingers	OFFICIAL
+en	nna	HP:0100490	rdfs:label	Camptodactyly of finger	Fingers Wirlki	OFFICIAL
+en	nna	HP:0040019	rdfs:label	Finger clinodactyly	Wupartu Finger Wirlki	OFFICIAL
+en	nna	HP:0100759	rdfs:label	Clubbing of fingers	Fingers Pijurnu	OFFICIAL
+en	nna	HP:0009486	rdfs:label	Radial deviation of the hand	Wrist Wirlki	OFFICIAL
+en	nna	HP:0009487	rdfs:label	Ulnar deviation of the hand	Wrist Wirlki	OFFICIAL
+en	nna	HP:0001839	rdfs:label	Split foot	Larr Jina	OFFICIAL
+en	nna	HP:0009380	rdfs:label	Aplasia of the fingers	Waraja Finger Majarri	OFFICIAL
+en	nna	HP:0001500	rdfs:label	Broad finger	Finger Walparra	OFFICIAL
+en	nna	HP:0001238	rdfs:label	Slender finger	Finger Wujul-Wujul	OFFICIAL
+en	nna	HP:0011299	rdfs:label	Partial absence of finger	Finger Kuta	OFFICIAL
+en	nna	HP:0009381	rdfs:label	Short finger	Finger Murlku	OFFICIAL
+en	nna	HP:0009465	rdfs:label	Ulnar deviation of finger	Finger Wirlki	OFFICIAL
+en	nna	HP:0001199	rdfs:label	Triphalangeal thumb	Thumb Makarnu	OFFICIAL
+en	nna	HP:0010554	rdfs:label	Cutaneous finger syndactyly	Fingers Warajanga	OFFICIAL
+en	nna	HP:0100807	rdfs:label	Long fingers	Makanu Fingers	OFFICIAL
+en	nna	HP:0001831	rdfs:label	Short toe	Murlku Toe	OFFICIAL
+en	nna	HP:0001769	rdfs:label	Broad foot	Walpurra Toe	OFFICIAL
+en	nna	HP:0030032	rdfs:label	Partial absence of foot	Jina Kuta	OFFICIAL
+en	nna	HP:0001838	rdfs:label	Rocker bottom foot	Jina Wirtu	OFFICIAL
+en	nna	HP:0001773	rdfs:label	Short foot	Murlku Jina	OFFICIAL
+en	nna	HP:0012386	rdfs:label	Absent hallux	Mamartua Majirri	OFFICIAL
+en	nna	HP:0010055	rdfs:label	Broad hallux	Mamartua Wirtu	OFFICIAL
+en	nna	HP:0001171	rdfs:label	Split hand	Laar Parirr	OFFICIAL
+en	nna	HP:0011302	rdfs:label	Long palm	Makanu Ngalukarti	OFFICIAL
+en	nna	HP:0004283	rdfs:label	Narrow palm	Wujul-Wujul  Ngalukarti	OFFICIAL
+en	nna	HP:0012428	rdfs:label	Prominent calcaneus	Heel Wirtu	OFFICIAL
+en	nna	HP:0009601	rdfs:label	Aplasia/Hypoplasia of the thumb	Thumb Majirri	OFFICIAL
+en	nna	HP:0010760	rdfs:label	Absent toe	Toe Majirri	OFFICIAL
+en	nna	HP:0011305	rdfs:label	Partial absence of toe	Toe Kuta	OFFICIAL
+en	nna	HP:0010170	rdfs:label	Small epiphyses of the toes	Mulrku Toes	OFFICIAL
+en	nna	HP:0010511	rdfs:label	Long toe	Makanu Toes	OFFICIAL
+en	nna	HP:0011308	rdfs:label	Slender toe	Wujul-Wujul toes	OFFICIAL
+en	nna	HP:0011309	rdfs:label	Tapered toe	Yiti Toe	OFFICIAL
+en	nna	HP:0010055	rdfs:label	Broad hallux	Walpurra Toe	OFFICIAL
+en	nna	HP:0001598	rdfs:label	Concave nail	Milpiny Wirtu Martu	OFFICIAL
+en	nna	HP:0001792	rdfs:label	Small nail	Wupartu Milpiny	OFFICIAL
+en	nna	HP:0011313	rdfs:label	Narrow nail	Wujul Wujul Mipiny	OFFICIAL
+en	nna	HP:0001803	rdfs:label	Nail pits	Milpiny Wupart Martu	OFFICIAL
+en	nna	HP:0010793	rdfs:label	Bifid nail	Warrajanga Milpinyjirri	OFFICIAL
+en	nna	HP:0001795	rdfs:label	Hyperconvex nail	Mipiny Kankakurnu	OFFICIAL
+en	nna	HP:0001799	rdfs:label	Short nail	Mipiny Murlku	OFFICIAL
+en	nna	HP:0001809	rdfs:label	Split nail	Milpiny laarr	OFFICIAL
+en	nna	HP:0001805	rdfs:label	Onychogryposis	Milpiny Wirtu	OFFICIAL
+en	nna	HP:0001816	rdfs:label	Thin nail	Milpiny Wupartu	OFFICIAL
+en	nna	HP:0001598	rdfs:label	Concave nail	Milpiny Kaninykurnu	OFFICIAL

--- a/babelon/hp-nna.babelon.tsv
+++ b/babelon/hp-nna.babelon.tsv
@@ -191,11 +191,11 @@ en	nna	HP:0011309	rdfs:label	Tapered toe	Yiti Toe	OFFICIAL
 en	nna	HP:0010055	rdfs:label	Broad hallux	Walpurra Toe	OFFICIAL
 en	nna	HP:0001598	rdfs:label	Concave nail	Milpiny Wirtu Martu	OFFICIAL
 en	nna	HP:0001792	rdfs:label	Small nail	Wupartu Milpiny	OFFICIAL
-en	nna	HP:0011313	rdfs:label	Narrow nail	Wujul Wujul Mipiny	OFFICIAL
+en	nna	HP:0011313	rdfs:label	Narrow nail	Wujul Wujul Milpiny	OFFICIAL
 en	nna	HP:0001803	rdfs:label	Nail pits	Milpiny Wupart Martu	OFFICIAL
 en	nna	HP:0010793	rdfs:label	Bifid nail	Warrajanga Milpinyjirri	OFFICIAL
-en	nna	HP:0001795	rdfs:label	Hyperconvex nail	Mipiny Kankakurnu	OFFICIAL
-en	nna	HP:0001799	rdfs:label	Short nail	Mipiny Murlku	OFFICIAL
+en	nna	HP:0001795	rdfs:label	Hyperconvex nail	Milpiny Kankakurnu	OFFICIAL
+en	nna	HP:0001799	rdfs:label	Short nail	Milpiny Murlku	OFFICIAL
 en	nna	HP:0001809	rdfs:label	Split nail	Milpiny laarr	OFFICIAL
 en	nna	HP:0001805	rdfs:label	Onychogryposis	Milpiny Wirtu	OFFICIAL
 en	nna	HP:0001816	rdfs:label	Thin nail	Milpiny Wupartu	OFFICIAL


### PR DESCRIPTION
Contributors: Yarlalu Thomas, Gareth Baynam (ORCID ID: 0000-0003-4920-9553)
Description of the translation: Translation was performed by the Nyangumarta Lyfe Languages champion Yarlalu Thomas in consultation with and the approval of Aboriginal Community Elders. The Lyfe Languages project is aimed at breaking down these barriers to communication by translating medical resources and terminology into the languages spoken by Indigenous communities. The translation was used to prepare and publish health and educational materials initially for rare diseases, then COVID-19 and subsequently extending to all health domains.